### PR TITLE
Document device details lambda sql retry and staging table logic

### DIFF
--- a/Device_Details_Lambda_Analysis.md
+++ b/Device_Details_Lambda_Analysis.md
@@ -1,0 +1,140 @@
+# Device Details Lambda Analysis
+
+## SQL Retry Implementation and Issue Prevention
+
+### Why SQL Retry is Done First
+
+The SQL retry mechanism in the Device Details Lambda is implemented **at the beginning of critical database operations** for the following reasons:
+
+#### 1. **Proactive Error Handling Strategy**
+```csharp
+var sqlRetryPolicy = GetSqlRetryPolicy(context);
+sqlRetryPolicy.Execute(() => {
+    // Database operations here
+});
+```
+
+The SQL retry policy is established **before** any database operations begin in the `ProcessDetailListAsync` method (line 225). This ensures that all subsequent SQL operations are protected by the retry mechanism from the start.
+
+#### 2. **Transient Error Prevention**
+The retry policy specifically targets **transient SQL errors** that are common in cloud environments:
+
+```csharp
+private static RetryPolicy GetSqlRetryPolicy(KeySysLambdaContext context)
+{
+    var sqlTransientRetryPolicy = Policy
+        .Handle<SqlException>(SqlServerTransientExceptionDetector.ShouldRetryOn)
+        .Or<TimeoutException>()
+        .WaitAndRetry(MaxRetries,
+            retryAttempt => TimeSpan.FromSeconds(RetryDelaySeconds),
+            (exception, timeSpan, retryCount, sqlContext) => LogInfo(context, "STATUS",
+                $"Encountered transient SQL error - delaying for {timeSpan.TotalMilliseconds}ms, then making retry {retryCount}. Exception: {exception?.Message}"));
+    return sqlTransientRetryPolicy;
+}
+```
+
+#### 3. **Issues Prevented by Early SQL Retry Implementation**
+
+**a) Connection Timeouts:**
+- Network latency issues between Lambda and SQL Server
+- Temporary database unavailability
+- Connection pool exhaustion
+
+**b) Transient Database Errors:**
+- Deadlocks during concurrent operations
+- Temporary resource unavailability
+- Database failover scenarios in high-availability setups
+
+**c) Data Consistency Issues:**
+- Prevents partial data updates due to connection failures
+- Ensures atomic operations complete successfully
+- Maintains data integrity during bulk operations
+
+**d) Lambda Execution Failures:**
+- Prevents entire Lambda function failure due to single SQL operation failure
+- Reduces need for manual intervention and reprocessing
+- Improves overall system reliability
+
+#### 4. **Retry Configuration**
+- **Maximum Retries:** 5 attempts (`MaxRetries = 5`)
+- **Retry Delay:** 5 seconds between attempts (`RetryDelaySeconds = 5`)
+- **Total Maximum Retry Time:** Up to 25 seconds for critical operations
+
+## Staging Table Clearing at Process Start
+
+### Device Detail Staging Tables
+
+The Device Details Lambda works with two main staging tables:
+
+1. **`TelegenceDeviceDetailStaging`** - Main device detail data
+2. **`TelegenceDeviceMobilityFeature_Staging`** - Device mobility features
+
+### Clearing Behavior Analysis
+
+#### ✅ **Feature Staging Table IS Cleared at Start**
+
+```csharp
+private async Task SendProcessMessagesToQueueAsync(KeySysLambdaContext context, int groupCount)
+{
+    LogInfo(context, "INFO", "Start execute RemovePreviouslyStagedFeatures");
+    RemovePreviouslyStagedFeatures(context);
+    LogInfo(context, "INFO", "End execute RemovePreviouslyStagedFeatures");
+    // ... rest of method
+}
+
+private void RemovePreviouslyStagedFeatures(KeySysLambdaContext context)
+{
+    using (var con = new SqlConnection(context.CentralDbConnectionString))
+    {
+        string cmdText = "TRUNCATE TABLE [dbo].[TelegenceDeviceMobilityFeature_Staging]";
+        using (var cmd = new SqlCommand(cmdText, con)
+        {
+            CommandType = CommandType.Text
+        })
+        {
+            con.Open();
+            cmd.CommandTimeout = 800;
+            cmd.ExecuteNonQuery();
+        }
+    }
+}
+```
+
+**When:** The `TelegenceDeviceMobilityFeature_Staging` table is **TRUNCATED** at the start of the daily processing cycle, specifically in the `SendProcessMessagesToQueueAsync` method.
+
+**Purpose:** This ensures clean processing by removing any leftover feature data from previous runs.
+
+#### ❌ **Main Device Detail Staging Table is NOT Cleared at Start**
+
+The main `TelegenceDeviceDetailStaging` table is **NOT** cleared at the beginning of processing. Instead:
+
+1. **Incremental Processing:** New device details are added to the staging table throughout the process
+2. **Selective Removal:** Processed devices are marked as deleted in the processing queue table:
+   ```csharp
+   UPDATE [dbo].[TelegenceDeviceDetailIdsToProcess]
+   SET [IsDeleted] = 1
+   WHERE GroupNumber = @GroupNumber 
+   AND SubscriberNumber IN (SELECT SubscriberNumber FROM [dbo].[TelegenceDeviceDetailStaging])
+   ```
+
+3. **No Initial Truncation:** The stored procedure `usp_Telegence_Devices_GetDetailFilter` is called at the start, but this manages the processing queue, not the staging table clearing.
+
+### Summary of Staging Table Behavior
+
+| Staging Table | Cleared at Start | Method | Purpose |
+|---------------|------------------|---------|---------|
+| `TelegenceDeviceMobilityFeature_Staging` | ✅ **YES** | `TRUNCATE TABLE` | Clean slate for device features |
+| `TelegenceDeviceDetailStaging` | ❌ **NO** | Incremental processing | Preserves existing data, adds new records |
+
+### BAN (Billing Account Number) Staging Tables
+
+**Note:** While not directly part of the Device Details Lambda, the related Device processing does clear BAN staging tables:
+- `TruncateTelegenceDeviceAndUsageStaging()` 
+- `TruncateTelegenceBillingAccountNumberStatusStaging()`
+
+These are cleared in the main device processing workflow but **not** in the Device Details Lambda specifically.
+
+## Conclusion
+
+1. **SQL Retry First:** Implemented proactively to prevent transient database errors, connection timeouts, and ensure data consistency
+2. **Staging Table Clearing:** Only the feature staging table is cleared at start; the main device detail staging table uses incremental processing without initial clearing


### PR DESCRIPTION
Add `Device_Details_Lambda_Analysis.md` to document SQL retry and staging table clearing behavior in the Device Details Lambda.

---
<a href="https://cursor.com/background-agent?bcId=bc-025e0b14-3bb8-4344-bd20-8b99c2792fab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-025e0b14-3bb8-4344-bd20-8b99c2792fab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

